### PR TITLE
Bump lower bound of base to `base >=4.9`

### DIFF
--- a/filtrable.cabal
+++ b/filtrable.cabal
@@ -17,7 +17,7 @@ tested-with:         GHC ==8.0.*
 
 library
   exposed-modules:     Data.Filtrable
-  build-depends:       base >=4.7 && <5
+  build-depends:       base >=4.9 && <5
   default-language:    Haskell2010
   default-extensions:  ConstrainedClassMethods
   ghc-options:         -Wall -Wcompat -Wredundant-constraints -Wno-name-shadowing


### PR DESCRIPTION
I made corresponding revisions
- https://hackage.haskell.org/package/filtrable-0.1.2.0/revisions/ 
- https://hackage.haskell.org/package/filtrable-0.1.3.0/revisions/

as the some of ghc-options used is not available on older GHCs,
thus causing actual build failures.